### PR TITLE
Add tf2centerprojectiles plugin

### DIFF
--- a/roles/tf2/files/tf/addons/sourcemod/gamedata/tf2.attributes.txt
+++ b/roles/tf2/files/tf/addons/sourcemod/gamedata/tf2.attributes.txt
@@ -1,0 +1,82 @@
+"Games"
+{
+	/* Team Fortress 2 */
+	"tf"
+	{
+		"Offsets"
+		{
+			"CAttributeManager::OnAttributeValuesChanged"
+			{
+				"windows"	"13"
+				"linux"		"14"
+				"mac"		"14"
+			}
+		}
+		"Signatures"
+		{
+			"CEconItemSchema::GetItemDefinition"	//(int), returns CEconItemDefinition*
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x56\x8B\xF1\x8D\x45\x08\x57\x50\x8D\x8E\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x85\xC0"
+				"linux"				"@_ZN15CEconItemSchema17GetItemDefinitionEi"
+				"mac"				"@_ZN15CEconItemSchema17GetItemDefinitionEi"
+			}
+			"CEconItemView::GetSOCData"	//(), returns CEconItem*
+			{
+				"library"			"server"
+				"windows"			"\x56\x8B\xF1\x8B\x46\x2A\x85\xC0\x75\x2A\xE8\x2A\x2A\x2A\x2A\xFF\x76\x20\x8B\xC8\x8B\x10\xFF\x52\x44\x85\xC0\x74\x2A\xFF\x76\x14\x8B\xC8\xFF\x76\x10\xE8\x2A\x2A\x2A\x2A\x5E"
+				"linux"				"@_ZNK13CEconItemView10GetSOCDataEv"
+				"mac"				"@_ZNK13CEconItemView10GetSOCDataEv"
+			}
+			"GEconItemSchema"	//static?
+			{
+				"library"			"server"
+				"windows"			"\xE8\x2A\x2A\x2A\x2A\x83\xC0\x04\xC3"
+				"linux"				"@_Z15GEconItemSchemav"
+				"mac"				"@_Z15GEconItemSchemav"
+			}
+			"CEconItemSchema::GetAttributeDefinition"	//(int), returns CEconItemAttributeDefinition*
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x2A\x53\x56\x8B\xD9\x8D\x2A\x2A\x57"
+				"linux"				"@_ZN15CEconItemSchema22GetAttributeDefinitionEi"
+				"mac"				"@_ZN15CEconItemSchema22GetAttributeDefinitionEi"
+			}
+			"CEconItemSchema::GetAttributeDefinitionByName"	//(const char*), returns CEconItemAttributeDefinition*
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x14\x53\x8B\x5D\x08\x56\x57\x8B\xF9\x85\xDB"
+				"linux"				"@_ZN15CEconItemSchema28GetAttributeDefinitionByNameEPKc"
+				"mac"				"@_ZN15CEconItemSchema28GetAttributeDefinitionByNameEPKc"
+			}
+			"CAttributeList::RemoveAttribute" //(CEconItemAttributeDefinition*), returns CEconItemAttributeDefinition*
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x51\x53\x8B\xD9\x56\x33\xF6\x8B\x43\x10\x89\x45\xFC\x85\xC0\x7E\x2A\x57\x33\xFF"
+				"linux"				"@_ZN14CAttributeList15RemoveAttributeEPK28CEconItemAttributeDefinition"
+				"mac"				"@_ZN14CAttributeList15RemoveAttributeEPK28CEconItemAttributeDefinition"
+			}
+			"CAttributeList::SetRuntimeAttributeValue" //(CEconItemAttributeDefinition*, float), returns void
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x2A\x33\x2A\x53\x8B\xD9\x56\x57\x8B\x2A\x2A\x8B\x2A\x2A"
+				"linux"				"@_ZN14CAttributeList24SetRuntimeAttributeValueEPK28CEconItemAttributeDefinitionf"
+				"mac"				"@_ZN14CAttributeList24SetRuntimeAttributeValueEPK28CEconItemAttributeDefinitionf"
+			}
+			"CAttributeList::GetAttributeByID" //(int), returns CEconAttribute*
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x51\x8B\xC1\x53\x56\x33\xF6\x89\x45\xFC\x8B\x58\x10"
+				"linux"				"@_ZNK14CAttributeList16GetAttributeByIDEi"
+				"mac"				"@_ZNK14CAttributeList16GetAttributeByIDEi"
+			}
+			"CAttributeList::DestroyAllAttributes" //(), returns int
+			{
+				"library"			"server"
+				"windows"			"\x56\x8B\xF1\x83\x7E\x10\x00\x74\x2A\xC7\x46\x10\x00\x00\x00\x00"
+				"linux"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
+				"mac"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
+			}
+		}
+	}
+}

--- a/roles/tf2/files/tf/addons/sourcemod/gamedata/tf2centerprojectiles.games.txt
+++ b/roles/tf2/files/tf/addons/sourcemod/gamedata/tf2centerprojectiles.games.txt
@@ -1,0 +1,21 @@
+"Games"
+{
+	"tf"
+	{
+		"Offsets"
+		{
+			// https://asherkin.github.io/vtable/
+			"Weapon_ShootPosition"
+			{
+				"windows" "268"
+				"linux"   "269"
+			}
+			// https://asherkin.github.io/vtable/
+			"IsViewModelFlipped"
+			{
+				"windows" "432"
+				"linux"   "439"
+			}
+		}
+	}
+}

--- a/roles/tf2/files/tf/addons/sourcemod/scripting/include/tf2attributes.inc
+++ b/roles/tf2/files/tf/addons/sourcemod/scripting/include/tf2attributes.inc
@@ -1,0 +1,306 @@
+#if defined _tf2attributes_included
+  #endinput
+#endif
+#define _tf2attributes_included
+
+/**
+ * Sets an attribute's value on an entity, adding it if it isn't on the entity.
+ *
+ * @param iEntity		Entity index to set the attribute on. Must have m_AttributeList.
+ * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
+ * @param flValue		Value to set the attribute to
+ *
+ * @return				True if the attribute was added successfully, false if entity does not have m_AttributeList.
+ * @error				Invalid entity index or attribute name passed.
+ */
+native bool TF2Attrib_SetByName(int iEntity, char[] strAttrib, float flValue);
+
+/**
+ * Sets an attribute's value on an entity, adding it if it isn't on the entity.
+ *
+ * @param iEntity		Entity index to set the attribute on. Must have m_AttributeList.
+ * @param iDefIndex		Definition index of the attribute, as from the number on the attribute entry in items_game.
+ * @param flValue		Value to set the attribute to
+ *
+ * @return				True if the attribute was added successfully, false if entity does not have m_AttributeList.
+ * @error				Invalid entity index or attribute name passed.
+ */
+native bool TF2Attrib_SetByDefIndex(int iEntity, int iDefIndex, float flValue);
+
+/**
+ * Returns the address of an attribute on an entity.
+ *
+ * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
+ * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
+ *
+ * @return				Address of the attribute on the entity, or Address_Null if the attribute does not exist on the entity.
+ * @error				Invalid entity index or attribute name passed.
+ */
+native Address TF2Attrib_GetByName(int iEntity, char[] strAttrib);
+
+/**
+ * Returns the address of an attribute (by attribute index) on an entity.
+ *
+ * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
+ * @param iDefIndex		Definition index of the attribute, as from the number on the attribute entry in items_game.
+ *
+ * @return				Address of the attribute on the entity, or Address_Null if the attribute does not exist on the entity.
+ * @error				Invalid entity index or attribute index passed.
+ */
+native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex);
+
+/**
+ * Removes an attribute from an entity.
+ *
+ * @param iEntity		Entity index to remove attribute from. Must have m_AttributeList.
+ * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
+ *
+ * @return				True if the SDKCall was made, false if entity had invalid address or m_AttributeList missing.
+ * @error				Invalid entity index or attribute name passed.
+ */
+native bool TF2Attrib_RemoveByName(int iEntity, char[] strAttrib);
+
+/**
+ * Removes an attribute from an entity.
+ *
+ * @param iEntity		Entity index to remove attribute from. Must have m_AttributeList.
+ * @param iDefIndex		Definition index of the attribute, as from the number on the attribute entry in items_game.
+ *
+ * @return				True if the SDKCall was made, false if entity had invalid address or m_AttributeList missing.
+ * @error				Invalid entity index or attribute index passed.
+ */
+native bool TF2Attrib_RemoveByDefIndex(int iEntity, int iDefIndex);
+
+/**
+ * Removes all attributes from an entity.
+ *
+ * @param iEntity		Entity index to remove attribute from. Must have m_AttributeList.
+ *
+ * @return				True if the SDKCall was made, false if entity had invalid address or m_AttributeList missing.
+ * @error				Invalid entity index passed.
+ */
+native bool TF2Attrib_RemoveAll(int iEntity);
+
+/**
+ * Clears and presumably rebuilds the attribute cache for an entity, 'refreshing' attributes.
+ * Call this after making changes to an attribute with any of the TF2Attrib_Set*(Address pAttrib, arg) natives below.
+ * You may also need to call this on the entity's m_hOwnerEntity if it is a weapon or wearable.
+ * You do NOT need to call this after calls to TF2Attrib_SetByName, TF2Attrib_Remove, and TF2Attrib_RemoveAll.
+ *
+ * @param iEntity		Entity index to remove attribute from. Must have m_AttributeList.
+ *
+ * @return				True if the SDKCall was made, false if entity had invalid address or m_AttributeList missing.
+ * @error				Invalid entity index passed.
+ */
+native bool TF2Attrib_ClearCache(int iEntity);
+
+/**
+ * Sets the value of m_iAttributeDefinitionIndex (the attribute ID) on an attribute.
+ * Warning, this changes what GetByName/ID and SetByName 'see' as the name of the attribute,
+ * but will only change attribute's effects if TF2Attrib_ClearCache is called on the entity with the attribute after.
+ *
+ * @param pAttrib		Address of the attribute.
+ * @param iDefIndex		Value to set m_iAttributeDefinitionIndex to.
+ *
+ * @noreturn
+ */
+native void TF2Attrib_SetDefIndex(Address pAttrib, int iDefIndex);
+
+/**
+ * Returns the value of m_iAttributeDefinitionIndex (the attribute ID) on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ *
+ * @return				The integer value of m_iAttributeDefinitionIndex on the attribute.
+ */
+native int TF2Attrib_GetDefIndex(Address pAttrib);
+
+/**
+ * Sets the value of m_flValue on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ * @param flValue		Value to set m_flValue to.
+ *
+ * @noreturn
+ */
+native void TF2Attrib_SetValue(Address pAttrib, float flValue);
+
+/**
+ * Returns the value of m_flValue on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ *
+ * @return				The floating point value of m_flValue on the attribute.
+ */
+native float TF2Attrib_GetValue(Address pAttrib);
+
+/**
+ * Sets the value of m_nRefundableCurrency on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ * @param nCurrency		Value to set m_nRefundableCurrency to.
+ *
+ * @noreturn
+ */
+native void TF2Attrib_SetRefundableCurrency(Address pAttrib, int nCurrency);
+
+/**
+ * Returns the value of m_nRefundableCurrency on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ *
+ * @return				The (unsigned) integer value of m_nRefundableCurrency on the attribute.
+ */
+native int TF2Attrib_GetRefundableCurrency(Address pAttrib);
+
+/**
+ * Returns an array containing the attributes (as indices) present on an entity.
+ *
+ * @param iEntity		Entity index to get attribute list from. Must have m_AttributeList.
+ * @param iDefIndices	Array of attribute definition indices found on the entity.
+ * @param iMaxLen		Max length of the iDefIndices array, default 20. Does not affect the return value.
+ *
+ * @return				The number of attributes found on the entity's attribute list (max 20 as of Oct 2017), or -1 if some error happened.
+ * @error				Invalid iEntity or iMaxLen.
+ */
+native int TF2Attrib_ListDefIndices(int iEntity, int[] iDefIndices, int iMaxLen=20);
+
+/**
+ * Returns arrays containing the static attributes and their values present on an item definition.
+ *
+ * @param iItemDefIndex		Item definition index (e.g. 7 for Shovel) to get static attribute list from.
+ * @param iAttribIndices	Array of attribute definition indices found on the item definition.
+ * @param flAttribValues	Array of attribute values found on the item definition, corresponding to the indices.
+ * @param iMaxLen			Max length of the two arrays passed in, default 16. Does not affect the return value.
+ *
+ * @return					The number of attributes found on the item definition's static attribute list (max 16 as of June 2017), or -1 if no schema or item definition found.
+ * @error					Invalid iMaxLen, or gamedata for this function failed to load.
+ */
+native int TF2Attrib_GetStaticAttribs(int iItemDefIndex, int[] iAttribIndices, float[] flAttribValues, int iMaxLen=16);
+
+/**
+ * Returns arrays containing the item server (SOC) attributes and their values present on an item definition.
+ *
+ * @param iEntity			Entity index to get the item server attribute list from.
+ * @param iAttribIndices	Array of attribute definition indices found.
+ * @param flAttribValues	Array of attribute values found, corresponding to the indices.
+ * @param iMaxLen			Max length of the two arrays passed in, default 16. Does not affect the return value.
+ *
+ * @return					The number of attributes found on the item's SOC attribute list (max 16 as of June 2017), or -1 if some error happened.
+ * @error					Invalid iEntity or iMaxLen, or gamedata for this function failed to load.
+ */
+native int TF2Attrib_GetSOCAttribs(int iEntity, int[] iAttribIndices, float[] flAttribValues, int iMaxLen=16);
+
+/**
+ * Gets whether an attribute is stored as an integer or as a float.
+ * Use TF2Attrib_SetValue(attribute, view_as<float>(intValue)) on attributes that store values as ints
+ *   to avoid compiler tag mismatch warnings.
+ *
+ * @param iDefIndex		Index of the attribute (as returned by TF2Attrib_GetDefIndex()).
+ *
+ * @return				True if attribute value is supposed to be an int, false if float.
+ */
+native bool TF2Attrib_IsIntegerValue(int iDefIndex);
+
+/**
+ * Gets whether the plugin loaded without ANY errors.
+ * For the purpose of allowing dependencies to ignore the plugin if this returns false.
+ * Check in OnAllPluginsLoaded() or something. I dunno.
+ *
+ * @return				True if no errors while loading, false otherwise.
+ */
+native bool TF2Attrib_IsReady();
+
+public SharedPlugin __pl_tf2attributes =
+{
+	name = "tf2attributes",
+	file = "tf2attributes.smx",
+#if defined REQUIRE_PLUGIN
+	required = 1,
+#else
+	required = 0,
+#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_tf2attributes_SetNTVOptional()
+{
+	MarkNativeAsOptional("TF2Attrib_SetByName");
+	MarkNativeAsOptional("TF2Attrib_SetByDefIndex");
+	MarkNativeAsOptional("TF2Attrib_GetByName");
+	MarkNativeAsOptional("TF2Attrib_GetByDefIndex");
+	MarkNativeAsOptional("TF2Attrib_RemoveByName");
+	MarkNativeAsOptional("TF2Attrib_RemoveByDefIndex");
+	MarkNativeAsOptional("TF2Attrib_RemoveAll");
+	MarkNativeAsOptional("TF2Attrib_ClearCache");
+	MarkNativeAsOptional("TF2Attrib_SetDefIndex");
+	MarkNativeAsOptional("TF2Attrib_GetDefIndex");
+	MarkNativeAsOptional("TF2Attrib_SetValue");
+	MarkNativeAsOptional("TF2Attrib_GetValue");
+	MarkNativeAsOptional("TF2Attrib_SetRefundableCurrency");
+	MarkNativeAsOptional("TF2Attrib_GetRefundableCurrency");
+	MarkNativeAsOptional("TF2Attrib_ListDefIndices");
+	MarkNativeAsOptional("TF2Attrib_GetStaticAttribs");
+	MarkNativeAsOptional("TF2Attrib_GetSOCAttribs");
+	MarkNativeAsOptional("TF2Attrib_ListDefIndices");
+	MarkNativeAsOptional("TF2Attrib_IsIntegerValue");
+	MarkNativeAsOptional("TF2Attrib_IsReady");
+
+//	MarkNativeAsOptional("TF2Attrib_SetInitialValue");
+//	MarkNativeAsOptional("TF2Attrib_GetInitialValue");
+//	MarkNativeAsOptional("TF2Attrib_SetIsSetBonus");
+//	MarkNativeAsOptional("TF2Attrib_GetIsSetBonus");
+}
+#endif
+
+//OLD things lie here
+//flInitialValue and bSetBonus don't exist anymore
+/**
+ * Sets the value of m_flInitialValue on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ * @param flValue		Value to set m_flInitialValue to.
+ *
+ * @noreturn
+ */
+//native TF2Attrib_SetInitialValue(Address pAttrib, float flValue);
+
+/**
+ * Returns the value of m_flInitialValue on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ *
+ * @return				The floating point value of m_flInitialValue on the attribute.
+ */
+//native float TF2Attrib_GetInitialValue(Address pAttrib);
+
+/**
+ * Sets the boolean value of m_bSetBonus on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ * @param bSetBonus		Value to set m_bSetBonus to.
+ *
+ * @noreturn
+ */
+//native TF2Attrib_SetIsSetBonus(Address pAttrib, bool bSetBonus);
+
+/**
+ * Returns the boolean value of m_bSetBonus on an attribute.
+ *
+ * @param pAttrib		Address of the attribute.
+ *
+ * @return				The boolean value of m_bSetBonus on the attribute.
+ */
+//native bool TF2Attrib_GetIsSetBonus(Address pAttrib);
+
+//stock TF2Attrib_IsIntegerValue(iDefIndex)
+//{
+//	switch (iDefIndex)
+//	{
+//		case 133, 143, 147, 152, 184, 185, 186, 192, 193, 194, 198, 211, 214, 227, 228, 229, 262, 294, 302, 372, 373, 374, 379, 381, 383, 403, 420:
+//		{
+//			return true;
+//		}
+//	}
+//	return false;
+//}

--- a/roles/tf2/files/tf/addons/sourcemod/scripting/tf2attributes.sp
+++ b/roles/tf2/files/tf/addons/sourcemod/scripting/tf2attributes.sp
@@ -1,0 +1,817 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdktools>
+
+#define PLUGIN_NAME		"[TF2] TF2Attributes"
+#define PLUGIN_AUTHOR		"FlaminSarge"
+#define PLUGIN_VERSION		"1.3.2"
+#define PLUGIN_CONTACT		"http://forums.alliedmods.net/showthread.php?t=210221"
+#define PLUGIN_DESCRIPTION	"Functions to add/get attributes for TF2 players/items"
+
+public Plugin:myinfo = {
+	name			= PLUGIN_NAME,
+	author			= PLUGIN_AUTHOR,
+	description		= PLUGIN_DESCRIPTION,
+	version			= PLUGIN_VERSION,
+	url				= PLUGIN_CONTACT
+};
+
+new Handle:hSDKGetItemDefinition;
+new Handle:hSDKGetSOCData;
+new Handle:hSDKSchema;
+new Handle:hSDKGetAttributeDef;
+new Handle:hSDKGetAttributeDefByName;
+new Handle:hSDKSetRuntimeValue;
+new Handle:hSDKGetAttributeByID;
+new Handle:hSDKOnAttribValuesChanged;
+new Handle:hSDKRemoveAttribute;
+new Handle:hSDKDestroyAllAttributes;
+
+//new Handle:hPluginReady;
+new bool:g_bPluginReady = false;
+public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+{
+	decl String:game[8];
+	GetGameFolderName(game, sizeof(game));
+	if (strncmp(game, "tf", 2, false) != 0)
+	{
+		strcopy(error, err_max, "Plugin only available for TF2 and possibly TF2Beta");
+		return APLRes_Failure;
+	}
+	CreateNative("TF2Attrib_SetByName", Native_SetAttrib);
+	CreateNative("TF2Attrib_SetByDefIndex", Native_SetAttribByID);
+	CreateNative("TF2Attrib_GetByName", Native_GetAttrib);
+	CreateNative("TF2Attrib_GetByDefIndex", Native_GetAttribByID);
+	CreateNative("TF2Attrib_RemoveByName", Native_Remove);
+	CreateNative("TF2Attrib_RemoveByDefIndex", Native_RemoveByID);
+	CreateNative("TF2Attrib_RemoveAll", Native_RemoveAll);
+	CreateNative("TF2Attrib_SetDefIndex", Native_SetID);
+	CreateNative("TF2Attrib_GetDefIndex", Native_GetID);
+	CreateNative("TF2Attrib_SetValue", Native_SetVal);
+	CreateNative("TF2Attrib_GetValue", Native_GetVal);
+	CreateNative("TF2Attrib_SetRefundableCurrency", Native_SetCurrency);
+	CreateNative("TF2Attrib_GetRefundableCurrency", Native_GetCurrency);
+	CreateNative("TF2Attrib_ClearCache", Native_ClearCache);
+	CreateNative("TF2Attrib_ListDefIndices", Native_ListIDs);
+	CreateNative("TF2Attrib_GetStaticAttribs", Native_GetStaticAttribs);
+	CreateNative("TF2Attrib_GetSOCAttribs", Native_GetSOCAttribs);
+	CreateNative("TF2Attrib_IsIntegerValue", Native_IsIntegerValue);
+	CreateNative("TF2Attrib_IsReady", Native_IsReady);
+	//hPluginReady = CreateGlobalForward("TF2Attrib_Ready", ET_Ignore);
+
+	//unused, backcompat I guess?
+	CreateNative("TF2Attrib_SetInitialValue", Native_SetInitialVal);
+	CreateNative("TF2Attrib_GetInitialValue", Native_GetInitialVal);
+	CreateNative("TF2Attrib_SetIsSetBonus", Native_SetSetBonus);
+	CreateNative("TF2Attrib_GetIsSetBonus", Native_GetSetBonus);
+
+	RegPluginLibrary("tf2attributes");
+	return APLRes_Success;
+}
+
+public Native_IsReady(Handle:plugin, numParams)
+{
+	return g_bPluginReady;
+}
+
+public OnPluginStart()
+{
+	new Handle:hGameConf = LoadGameConfigFile("tf2.attributes");
+	new bool:bPluginReady = true;	//we don't want to set g_bPluginReady BEFORE any of the checks... do we? W/e, I never asked for this.
+	if (hGameConf == INVALID_HANDLE)
+	{
+		SetFailState("Could not locate gamedata file tf2.attributes.txt for TF2Attributes, pausing plugin");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CEconItemSchema::GetItemDefinition");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of CEconItemDefinition
+	hSDKGetItemDefinition = EndPrepSDKCall();
+	if (hSDKGetItemDefinition == INVALID_HANDLE)
+	{
+		LogError("Could not initialize call to CEconItemSchema::GetItemDefinition");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CEconItemView::GetSOCData");
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of CEconItem
+	hSDKGetSOCData = EndPrepSDKCall();
+	if (hSDKGetSOCData == INVALID_HANDLE)
+	{
+		LogError("Could not initialize call to CEconItemView::GetSOCData");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Static);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "GEconItemSchema");
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of CEconItemSchema
+	hSDKSchema = EndPrepSDKCall();
+	if (hSDKSchema == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to GEconItemSchema");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CEconItemSchema::GetAttributeDefinition");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of a CEconItemAttributeDefinition
+	hSDKGetAttributeDef = EndPrepSDKCall();
+	if (hSDKGetAttributeDef == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CEconItemSchema::GetAttributeDefinition");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CEconItemSchema::GetAttributeDefinitionByName");
+	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of a CEconItemAttributeDefinition
+	hSDKGetAttributeDefByName = EndPrepSDKCall();
+	if (hSDKGetAttributeDefByName == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CEconItemSchema::GetAttributeDefinitionByName");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CAttributeList::RemoveAttribute");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//not a clue what this return is
+	hSDKRemoveAttribute = EndPrepSDKCall();
+	if (hSDKRemoveAttribute == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CAttributeList::RemoveAttribute");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CAttributeList::SetRuntimeAttributeValue");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
+	//PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	//Apparently there's no return, so avoid setting return info, but the 'return' is nonzero if the attribute is added successfully
+	//Just a note, the above SDKCall returns ((entindex + 4) * 4) | 0xA000), and you can AND it with 0x1FFF to get back the entindex if you want, though it's pointless)
+	//I don't know any other specifics, such as if the highest 3 bits actually matter
+	//And I don't know what happens when you hit ent index 2047
+
+	hSDKSetRuntimeValue = EndPrepSDKCall();
+	if (hSDKSetRuntimeValue == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CAttributeList::SetRuntimeAttributeValue");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CAttributeList::DestroyAllAttributes");
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	hSDKDestroyAllAttributes = EndPrepSDKCall();
+	if (hSDKDestroyAllAttributes == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CAttributeList::DestroyAllAttributes");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CAttributeList::GetAttributeByID");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);	//Returns address of a CEconItemAttribute
+	hSDKGetAttributeByID = EndPrepSDKCall();
+	if (hSDKGetAttributeByID == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CAttributeList::GetAttributeByID");
+		bPluginReady = false;
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "CAttributeManager::OnAttributeValuesChanged");
+	hSDKOnAttribValuesChanged = EndPrepSDKCall();
+	if (hSDKOnAttribValuesChanged == INVALID_HANDLE)
+	{
+		SetFailState("Could not initialize call to CAttributeManager::OnAttributeValuesChanged");
+		bPluginReady = false;
+	}
+
+	CreateConVar("tf2attributes_version", PLUGIN_VERSION, "TF2Attributes version number", FCVAR_NOTIFY);
+//	Call_StartForward(hPluginReady);
+//	Call_Finish();
+	g_bPluginReady = bPluginReady;	//I really never asked for this.
+}
+
+stock bool:Internal_IsIntegerValue(iDefIndex)
+{
+	switch (iDefIndex)
+	{
+		case 133, 143, 147, 152, 184, 185, 186, 192, 193, 194, 198, 211, 214, 227, 228, 229, 262, 294, 302, 372, 373, 374, 379, 381, 383, 403, 420, 371, 500, 501, 2010, 2011, 2021, 2023, 2024:
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+public Native_IsIntegerValue(Handle:plugin, numParams)
+{
+	new iDefIndex = GetNativeCell(1);
+	return Internal_IsIntegerValue(iDefIndex);
+}
+
+stock GetStaticAttribs(Address:pItemDef, iAttribIndices[], iAttribValues[], size = 16)
+{
+	if (!IsValidAddress(pItemDef)) return 0;	//...-1 maybe?
+	new iNumAttribs = LoadFromAddress(pItemDef + Address:0x28, NumberType_Int32);
+	new Address:pAttribList = Address:LoadFromAddress(pItemDef + Address:0x1C, NumberType_Int32);
+	for (new i = 0; i < iNumAttribs && i < size; i++)	//THIS IS HOW YOU GET THE ATTRIBUTES ON AN ITEMDEF!
+	{
+		iAttribIndices[i] = LoadFromAddress(pAttribList + Address:(i * 8), NumberType_Int16);
+		iAttribValues[i] = LoadFromAddress(pAttribList + Address:(i * 8 + 4), NumberType_Int32);
+	}
+	return iNumAttribs;
+}
+
+public Native_GetStaticAttribs(Handle:plugin, numParams)
+{
+	new iItemDefIndex = GetNativeCell(1);
+	new size = 16;
+	if (numParams >= 4)
+	{
+		size = GetNativeCell(4);
+		if (size <= 0)
+		{
+			return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetStaticAttribs: Array size (iMaxLen=%d) must be greater than 0", size);
+		}
+	}
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return -1;
+	if (hSDKGetItemDefinition == INVALID_HANDLE)
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetStaticAttribs: Could not find call to CEconItemSchema::GetItemDefinition");
+	}
+	new Address:pItemDef = SDKCall(hSDKGetItemDefinition, pSchema, iItemDefIndex);
+	if (!IsValidAddress(pItemDef)) return -1;
+	new iAttribIndices[size], iAttribValues[size];
+	new iCount = GetStaticAttribs(pItemDef, iAttribIndices, iAttribValues, size);
+	SetNativeArray(2, iAttribIndices, size);
+	SetNativeArray(3, iAttribValues, size);	//cast to float on inc side
+	return iCount;
+}
+
+stock GetSOCAttribs(iEntity, iAttribIndices[], iAttribValues[], size = 16) {
+	if (size <= 0) {
+		return -1;
+	}
+	int iCEIVOffset = GetEntSendPropOffs(iEntity, "m_Item", true);
+	if (iCEIVOffset <= 0) {
+		return -1;
+	}
+	Address pEconItemView = GetEntityAddress(iEntity);
+	if (!IsValidAddress(pEconItemView)) {
+		return -1;
+	}
+	pEconItemView += view_as<Address>(iCEIVOffset);
+
+	Address pEconItem = SDKCall(hSDKGetSOCData, pEconItemView);
+	if (!IsValidAddress(pEconItem)) {
+		return -1;
+	}
+	Address pCustomData = view_as<Address>(LoadFromAddress(pEconItem + view_as<Address>(0x34), NumberType_Int32));
+	if (IsValidAddress(pCustomData)) {
+		int iCount = LoadFromAddress(pCustomData + view_as<Address>(0x0C), NumberType_Int32);
+		for (int i = 0; i < iCount && i < size; ++i) {
+			Address pAttribDef = view_as<Address>(LoadFromAddress(pCustomData, NumberType_Int32) + (i * 8));
+			Address pAttribVal = view_as<Address>(LoadFromAddress(pCustomData, NumberType_Int32) + (i * 8) + 4);
+			iAttribIndices[i] = LoadFromAddress(pAttribDef, NumberType_Int16);
+			iAttribValues[i] = LoadFromAddress(pAttribVal, NumberType_Int32);
+		}
+		return iCount;
+	}
+	//(CEconItem+0x27 & 0b100 & 0xFF) != 0
+	bool hasInternalAttribute = (LoadFromAddress(pEconItem + view_as<Address>(0x27), NumberType_Int8) & 0b100) != 0;
+	if (hasInternalAttribute) {
+		iAttribIndices[0] = LoadFromAddress(pEconItem + view_as<Address>(0x2C), NumberType_Int16);
+		iAttribValues[0] = LoadFromAddress(pEconItem + view_as<Address>(0x30), NumberType_Int32);
+		return 1;
+	}
+	return 0;
+}
+
+public Native_GetSOCAttribs(Handle:plugin, numParams)
+{
+	new iEntity = GetNativeCell(1);
+	new size = 16;
+	if (numParams >= 4)
+	{
+		size = GetNativeCell(4);
+		if (size <= 0)
+		{
+			return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetSOCAttribs: Array size (iMaxLen=%d) must be greater than 0", size);
+		}
+	}
+	if (!IsValidEntity(iEntity))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetSOCAttribs: Invalid entity (iEntity=%d) passed", iEntity);
+	}
+	if (hSDKGetSOCData == INVALID_HANDLE)
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetSOCAttribs: Could not find call to CEconItemView::GetSOCData");
+	}
+	//maybe move some address stuff to here from the stock, but for now it's okay
+	new iAttribIndices[size], iAttribValues[size];
+	new iCount = GetSOCAttribs(iEntity, iAttribIndices, iAttribValues, size);
+	SetNativeArray(2, iAttribIndices, size);
+	SetNativeArray(3, iAttribValues, size);	//cast to float on inc side
+	return iCount;
+}
+
+public Native_SetAttrib(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByName: Invalid entity (iEntity=%d) passed", entity);
+//		return;
+	}
+	decl String:strAttrib[128];	//"counts as assister is some kind of pet this update is going to be awesome" is 73 characters. Valve... Valve.
+	GetNativeString(2, strAttrib, sizeof(strAttrib));
+	new Float:flVal = GetNativeCell(3);
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByName: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return false;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null) return false;
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return false;
+	new Address:pAttribDef = SDKCall(hSDKGetAttributeDefByName, pSchema, strAttrib);
+	if (!IsValidAddress(pAttribDef))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByName: Attribute '%s' not valid", strAttrib);
+	}
+	SDKCall(hSDKSetRuntimeValue, pEntity+Address:offs, pAttribDef, flVal);
+	return true;
+
+//	ClearAttributeCache(GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
+//	decl String:strClassname[64];
+//	GetEntityClassname(entity, strClassname, sizeof(strClassname));
+//	if (strncmp(strClassname, "tf_wea", 6, false) == 0 || StrEqual(strClassname, "tf_powerup_bottle", false))
+//	{
+//		new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+//		if (client > 0 && client <= MaxClients && IsClientInGame(client)) ClearAttributeCache(client);
+//	}
+}
+
+public Native_SetAttribByID(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByDefIndex: Invalid entity (iEntity=%d) passed", entity);
+//		return;
+	}
+	new iAttrib = GetNativeCell(2);
+	new Float:flVal = GetNativeCell(3);
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByDefIndex: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return false;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null) return false;
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return false;
+	new Address:pAttribDef = SDKCall(hSDKGetAttributeDef, pSchema, iAttrib);
+	if (!IsValidAddress(pAttribDef))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetByDefIndex: Attribute %d not valid", iAttrib);
+	}
+	SDKCall(hSDKSetRuntimeValue, pEntity+Address:offs, pAttribDef, flVal);
+	return true;
+//	ClearAttributeCache(GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
+//	decl String:strClassname[64];
+//	GetEntityClassname(entity, strClassname, sizeof(strClassname));
+//	if (strncmp(strClassname, "tf_wea", 6, false) == 0 || StrEqual(strClassname, "tf_powerup_bottle", false))
+//	{
+//		new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+//		if (client > 0 && client <= MaxClients && IsClientInGame(client)) ClearAttributeCache(client);
+//	}
+}
+
+public Native_GetAttrib(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetByName: Invalid entity (iEntity=%d) passed", entity);
+//		return;
+	}
+	decl String:strAttrib[128];
+	GetNativeString(2, strAttrib, sizeof(strAttrib));
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetByName: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return _:Address_Null;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null) return _:Address_Null;
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return _:Address_Null;
+	new Address:pAttribDef = SDKCall(hSDKGetAttributeDefByName, pSchema, strAttrib);
+	if (!IsValidAddress(pAttribDef))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetByName: Attribute '%s' not valid", strAttrib);
+	}
+	new iDefIndex = LoadFromAddress(pAttribDef + Address:4, NumberType_Int16);
+	new Address:pAttrib = Address:SDKCall(hSDKGetAttributeByID, pEntity+Address:offs, iDefIndex);
+	return (!IsValidAddress(pAttrib) ? (_:Address_Null) : (_:pAttrib));
+}
+
+public Native_GetAttribByID(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetByDefIndex: Invalid entity (iEntity=%d) passed", entity);
+//		return;
+	}
+	new iDefIndex = GetNativeCell(2);
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetByName: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return _:Address_Null;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null) return _:Address_Null;
+	new Address:pAttrib = Address:SDKCall(hSDKGetAttributeByID, pEntity+Address:offs, iDefIndex);
+	return (!IsValidAddress(pAttrib) ? (_:Address_Null) : (_:pAttrib));
+}
+
+public Native_Remove(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveByName: Invalid entity (iEntity=%d) passed", entity);
+		return false;
+		// return;
+	}
+	decl String:strAttrib[128];
+	GetNativeString(2, strAttrib, sizeof(strAttrib));
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_Remove: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return false;
+		// return;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null)
+	{
+		return false;
+		// return;
+	}
+	if (pEntity == Address_Null) return false;
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return false;
+	new Address:pAttribDef = SDKCall(hSDKGetAttributeDefByName, pSchema, strAttrib);
+	if (!IsValidAddress(pAttribDef))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveByName: Attribute '%s' not valid", strAttrib);
+	}
+	SDKCall(hSDKRemoveAttribute, pEntity+Address:offs, pAttribDef);	//Not a clue what the return is here, but it's probably a clone of the attrib being removed
+
+//	SDKCall(hSDKRemoveAttribute, pEntity+Address:offs, strAttrib);
+//	ClearAttributeCache(GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
+//	decl String:strClassname[64];
+//	GetEntityClassname(entity, strClassname, sizeof(strClassname));
+//	if (strncmp(strClassname, "tf_wea", 6, false) == 0 || StrEqual(strClassname, "tf_powerup_bottle", false))
+//	{
+//		new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+//		if (client > 0 && client <= MaxClients && IsClientInGame(client)) ClearAttributeCache(client);
+//	}
+
+	return true;
+}
+
+public Native_RemoveByID(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveByDefIndex: Invalid entity (iEntity=%d) passed", entity);
+		return false;
+		// return;
+	}
+	new iAttrib = GetNativeCell(2);
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_Remove: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return false;
+		// return;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null)
+	{
+		return false;
+		// return;
+	}
+	if (pEntity == Address_Null) return false;
+	new Address:pSchema = SDKCall(hSDKSchema);
+	if (pSchema == Address_Null) return false;
+	new Address:pAttribDef = SDKCall(hSDKGetAttributeDef, pSchema, iAttrib);
+	if (!IsValidAddress(pAttribDef))
+	{
+		return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveByDefIndex: Attribute %d not valid", iAttrib);
+	}
+	SDKCall(hSDKRemoveAttribute, pEntity+Address:offs, pAttribDef);	//Not a clue what the return is here, but it's probably a clone of the attrib being removed
+
+//	SDKCall(hSDKRemoveAttribute, pEntity+Address:offs, strAttrib);
+//	ClearAttributeCache(GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
+//	decl String:strClassname[64];
+//	GetEntityClassname(entity, strClassname, sizeof(strClassname));
+//	if (strncmp(strClassname, "tf_wea", 6, false) == 0 || StrEqual(strClassname, "tf_powerup_bottle", false))
+//	{
+//		new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+//		if (client > 0 && client <= MaxClients && IsClientInGame(client)) ClearAttributeCache(client);
+//	}
+
+	return true;
+}
+
+public Native_RemoveAll(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveAll: Invalid entity (iEntity=%d) passed", entity);
+		return false;
+		// return;
+	}
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveAll: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return false;
+		// return;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null)
+	{
+		return false;
+		// return;
+	}
+	SDKCall(hSDKDestroyAllAttributes, pEntity+Address:offs);	//disregard the return (Valve does!)
+
+//	ClearAttributeCache(GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
+//	decl String:strClassname[64];
+//	GetEntityClassname(entity, strClassname, sizeof(strClassname));
+//	if (strncmp(strClassname, "tf_wea", 6, false) == 0 || StrEqual(strClassname, "tf_powerup_bottle", false))
+//	{
+//		new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+//		if (client > 0 && client <= MaxClients && IsClientInGame(client)) ClearAttributeCache(client);
+//	}
+
+	return true;
+}
+
+public Native_SetID(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return;
+	new iDefIndex = GetNativeCell(2);
+	StoreToAddress(pAttrib+Address:4, iDefIndex, NumberType_Int16);
+}
+
+public Native_GetID(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return -1;
+	return LoadFromAddress(pAttrib+Address:4, NumberType_Int16);
+}
+
+public Native_SetVal(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return;
+	new flVal = GetNativeCell(2);	//It's a float but avoiding tag mismatch warnings
+	StoreToAddress(pAttrib+Address:8, flVal, NumberType_Int32);
+}
+
+public Native_GetVal(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return -1;
+	return LoadFromAddress(pAttrib+Address:8, NumberType_Int32);
+}
+
+public Native_SetInitialVal(Handle:plugin, numParams)
+{
+	return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetInitialValue: m_flInitialValue is no longer present on attributes");
+
+//	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return;
+//	new flInitialVal = GetNativeCell(2);	//It's a float but avoiding tag mismatch warnings
+//	StoreToAddress(pAttrib+Address:12, flInitialVal, NumberType_Int32);
+}
+
+public Native_GetInitialVal(Handle:plugin, numParams)
+{
+	return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetInitialValue: m_flInitialValue is no longer present on attributes");
+
+//	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return -1;
+//	return LoadFromAddress(pAttrib+Address:12, NumberType_Int32);
+}
+
+public Native_SetCurrency(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return;
+	new nCurrency = GetNativeCell(2);
+	StoreToAddress(pAttrib+Address:12, nCurrency, NumberType_Int32);
+}
+
+public Native_GetCurrency(Handle:plugin, numParams)
+{
+	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return -1;
+	return LoadFromAddress(pAttrib+Address:12, NumberType_Int32);
+}
+
+public Native_SetSetBonus(Handle:plugin, numParams)
+{
+	return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_SetIsSetBonus: m_bSetBonus is no longer present on attributes");
+
+//	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return;
+//	new bool:bSetBonus = !!GetNativeCell(2);
+//	StoreToAddress(pAttrib+Address:20, bSetBonus, NumberType_Int8);
+}
+
+public Native_GetSetBonus(Handle:plugin, numParams)
+{
+	return ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_GetIsSetBonus: m_bSetBonus is no longer present on attributes");
+
+//	new Address:pAttrib = Address:GetNativeCell(1);
+//	if (!IsValidAddress(pAttrib)) return -1;
+//	return !!LoadFromAddress(pAttrib+Address:20, NumberType_Int8);
+}
+
+stock bool:ClearAttributeCache(entity)
+{
+	if (hSDKOnAttribValuesChanged == INVALID_HANDLE) return false;
+	if (entity <= 0 || !IsValidEntity(entity)) return false;
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0) return false;
+	new Address:pAttribs = GetEntityAddress(entity);
+	if (!IsValidAddress(pAttribs)) return false;
+	pAttribs = Address:LoadFromAddress(pAttribs+Address:(offs+24), NumberType_Int32);	//AttributeManager
+	if (!IsValidAddress(pAttribs)) return false;
+	SDKCall(hSDKOnAttribValuesChanged, pAttribs);
+	return true;
+}
+
+public Native_ClearCache(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	if (!IsValidEntity(entity))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_ClearCache: Invalid entity (iEntity=%d) passed", entity);
+		return false;
+	}
+	return ClearAttributeCache(entity);
+}
+
+public Native_ListIDs(Handle:plugin, numParams)
+{
+	new entity = GetNativeCell(1);
+	new size = 20;
+	if (numParams >= 3)
+	{
+		size = GetNativeCell(3);
+		if (size <= 0)
+		{
+			ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_ListDefIndices: Array size (iMaxLen=%d) must be greater than 0", size);
+			return -1;
+		}
+	}
+	if (!IsValidEntity(entity))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_ListDefIndices: Invalid entity (iEntity=%d) passed", entity);
+		return -1;
+	}
+
+	new offs = GetEntSendPropOffs(entity, "m_AttributeList", true);
+	if (offs <= 0)
+	{
+//		decl String:strClassname[64];
+//		if (!GetEntityClassname(entity, strClassname, sizeof(strClassname))) strClassname = "";
+//		ThrowNativeError(SP_ERROR_NATIVE, "TF2Attrib_RemoveAll: \"m_AttributeList\" not found (entity %d/%s)", entity, strClassname);
+		return -1;
+		// return;
+	}
+	new Address:pEntity = GetEntityAddress(entity);
+	if (pEntity == Address_Null)
+	{
+		return -1;
+		// return;
+	}
+	new Address:pAttribList = Address:LoadFromAddress(pEntity + Address:(offs + 4), NumberType_Int32);
+	if (!IsValidAddress(pAttribList)) return -1;
+	new iNumAttribs = LoadFromAddress(pEntity + Address:(offs + 16), NumberType_Int32);
+	new iAttribIndices[size];
+	for (new i = 0; i < iNumAttribs && i < size; i++)	//THIS IS HOW YOU GET THE ATTRIBUTES ON AN ITEM!
+	{
+		iAttribIndices[i] = LoadFromAddress(pAttribList + Address:(i * 16 + 4), NumberType_Int16);
+	}
+	SetNativeArray(2, iAttribIndices, size);
+	return iNumAttribs;
+}
+
+//TODO Stop using Address_MinimumValid once verified that logic still works without it
+stock bool IsValidAddress(Address pAddress)
+{
+	static Address Address_MinimumValid = view_as<Address>(0x10000);
+	if (pAddress == Address_Null)
+		return false;
+	return unsigned_compare(view_as<int>(pAddress), view_as<int>(Address_MinimumValid)) >= 0;
+}
+stock int unsigned_compare(int a, int b) {
+	if (a == b)
+		return 0;
+	if ((a >>> 31) == (b >>> 31))
+		return ((a & 0x7FFFFFFF) > (b & 0x7FFFFFFF)) ? 1 : -1;
+	return ((a >>> 31) > (b >>> 31)) ? 1 : -1;
+}
+/*
+struct CEconItemAttributeDefinition
+{
+	WORD index,						//4
+	WORD blank,
+	DWORD type,						//8
+	BYTE hidden,					//12
+	BYTE force_output_description,	//13
+	BYTE stored_as_integer,			//14
+	BYTE instance_data,				//15
+	BYTE is_set_bonus,				//16
+	BYTE blank,
+	BYTE blank,
+	BYTE blank,
+	DWORD is_user_generated,		//20
+	DWORD effect_type,				//24
+	DWORD description_format,		//28
+	DWORD description_string,		//32
+	DWORD armory_desc,				//36
+	DWORD name,						//40
+	DWORD attribute_class,			//44
+	BYTE can_affect_market_name,	//48
+	BYTE can_affect_recipe_component_name,	//49
+	BYTE blank,
+	BYTE blank,
+	DWORD apply_tag_to_item_definition,	//52
+	DWORD unknown
+
+};*/
+/*class CEconItemAttribute
+{
+public:
+	void *m_pVTable; //0
+
+	uint16 m_iAttributeDefinitionIndex; //4
+	float m_flValue; //8
+	int32 m_nRefundableCurrency; //12
+-----removed	float m_flInitialValue; //12
+-----removed	bool m_bSetBonus; //20
+};
+and +24 is still attribute manager
+*/

--- a/roles/tf2/files/tf/addons/sourcemod/scripting/tf2centerprojectiles.sp
+++ b/roles/tf2/files/tf/addons/sourcemod/scripting/tf2centerprojectiles.sp
@@ -1,0 +1,189 @@
+/*
+Copyright 2020, rtldg
+
+Copying and distribution of this file, with or without modification, are permitted in any medium without royalty, provided the copyright notice and this notice are preserved. This file is offered as-is, without any warranty.
+*/
+
+#include <sourcemod>
+#include <clientprefs>
+#include <tf2_stocks>
+#include <dhooks> // https://github.com/peace-maker/DHooks2
+
+#include <tf2attributes> // https://github.com/FlaminSarge/tf2attributes
+
+public Plugin myinfo = {
+	name = "[TF2] Center Projectiles",
+	author = "rtldg & pufftwitt",
+	version = "6.9",
+	url = "https://github.com/rtldg/tf2centerprojectiles",
+	description = "Provides the command sm_centerprojectiles [0|1] to shoot rockets from the center (like The Original) for any rocket launcher, shoot pipebombs and sticky bombs from the center, and more!"
+};
+
+bool g_bLate;
+Handle g_hCenterProjectiles;
+Handle g_hWeapon_ShootPosition = null;
+Handle g_hIsViewModelFlipped = null;
+
+float g_fOffset_FirePipeBomb = 8.0;
+
+stock bool IsValidClient(int client, bool bAlive = false)
+{
+	return (client >= 1 && client <= MaxClients && IsClientConnected(client) && IsClientInGame(client) && !IsClientSourceTV(client) && (!bAlive || IsPlayerAlive(client)));
+}
+
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
+	g_bLate = late;
+}
+
+public void OnPluginStart()
+{
+	RegConsoleCmd("sm_centerprojectiles", sm_centerprojectiles, "sm_centerprojectiles to toggle or sm_centerprojectiles [1|0] to set");
+	g_hCenterProjectiles = RegClientCookie("tf2centerprojectiles", "TF2 Center Projectiles thing", CookieAccess_Protected);
+	
+	// Called every player spawn...
+	HookEvent("player_spawn", Event_EverythingEver, EventHookMode_Post);
+	// Sent when a player gets a whole new set of items, aka touches a resupply locker / respawn cabinet or spawns in.
+	HookEvent("post_inventory_application", Event_EverythingEver, EventHookMode_Post);
+
+	Handle hGameData = LoadGameConfigFile("tf2centerprojectiles.games");
+
+	if (hGameData == null)
+	{
+		SetFailState("Failed to load tf2centerprojectiles gamedata");
+	}
+
+	int offset;
+	
+	if ((offset = GameConfGetOffset(hGameData, "Weapon_ShootPosition")) == -1)
+	{
+		SetFailState("Couldn't get the offset for Weapon_ShootPosition");
+	}
+
+	g_hWeapon_ShootPosition = DHookCreate(offset, HookType_Entity, ReturnType_Vector, ThisPointer_CBaseEntity, Hook_Weapon_ShootPosition);
+
+	StartPrepSDKCall(SDKCall_Entity);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "IsViewModelFlipped");
+	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
+	g_hIsViewModelFlipped = EndPrepSDKCall();
+
+	if (g_bLate)
+	{
+		for(int i = 1; i <= MaxClients; i++)
+		{
+			if (IsValidClient(i))
+			{
+				OnClientPutInServer(i);
+			}
+		}
+	}
+}
+
+public void OnClientPutInServer(int client)
+{
+	if (g_hWeapon_ShootPosition != null)
+	{
+		DHookEntity(g_hWeapon_ShootPosition, true, client);
+	}
+}
+
+// Hook to work with FirePipeBomb... aka grenade launcher & pipebomb launcher
+public MRESReturn Hook_Weapon_ShootPosition(int client, DHookReturn hReturn)
+{
+	if (!GetCentered(client))
+	{
+		return MRES_Ignored;
+	}
+
+	int weapon = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+
+	if (weapon == 0 || weapon == -1) // probably good enough check...
+	{
+		return MRES_Ignored;
+	}
+
+	char classname[64];
+	GetEntityClassname(weapon, classname, sizeof(classname));
+
+	if (!StrEqual(classname, "tf_weapon_grenadelauncher") && !StrEqual(classname, "tf_weapon_pipebomblauncher"))
+	{
+		return MRES_Ignored;
+	}
+
+	float pos[3];
+	GetClientEyePosition(client, pos);
+
+	float ang[3], fwd[3], right[3], up[3];
+	GetClientEyeAngles(client, ang);
+	GetAngleVectors(ang, fwd, right, up);
+
+	// We need to return a ShootPosition that'll return the center once the game has added the offset.
+	// i.e. subtract g_fOffset_FirePipeBomb and then the game adds g_fOffset_FirePipeBomb
+	bool isFlipped = SDKCall(g_hIsViewModelFlipped, weapon);
+	ScaleVector(right, g_fOffset_FirePipeBomb * (isFlipped ? -1.0 : 1.0));
+	SubtractVectors(pos, right, pos);
+
+	hReturn.SetVector(pos);
+	return MRES_Override;
+}
+
+Action sm_centerprojectiles(int client, int args)
+{
+	if (client < 1 || !IsClientInGame(client) || IsFakeClient(client))
+		return Plugin_Handled;
+
+	bool center;
+
+	if (args == 0)
+	{
+		center = !GetCentered(client);
+	}
+	else
+	{
+		char arg[128];
+		GetCmdArg(1, arg, sizeof(arg));
+		center = !(0 == StringToInt(arg, 10));
+	}
+
+	SetCentered(client, center);
+	SetCenterAttribute(client);
+	PrintToChat(client, "[TF2 Center Projectiles] %s", center ? "Enabled" : "Disabled");
+	return Plugin_Handled;
+}
+
+Action Event_EverythingEver(Event event, const char[] name, bool dontBroadcast)
+{
+	SetCenterAttribute(GetClientOfUserId(event.GetInt("userid")));
+	return Plugin_Continue;
+}
+
+bool GetCentered(int client)
+{
+	char cookie[2];
+	GetClientCookie(client, g_hCenterProjectiles, cookie, sizeof(cookie));
+	return cookie[0] == '1';
+}
+
+void SetCentered(int client, bool center)
+{
+	char cookie[2];
+	cookie[0] = center ? '1' : '0';
+	SetClientCookie(client, g_hCenterProjectiles, cookie);
+}
+
+void SetCenterAttribute(int client)
+{
+	if (IsFakeClient(client))
+		return;
+
+	int weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Primary);
+	if (weapon == -1) // How could this happen? :thinking:
+		return;
+
+	bool isTheOriginal = (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 513);
+	bool center = GetCentered(client) || isTheOriginal;
+
+	// List of attributes at https://wiki.teamfortress.com/wiki/List_of_item_attributes
+	// 289 == centerfire_projectile
+	TF2Attrib_SetByDefIndex(weapon, 289, center ? 1.0 : 0.0); 
+}


### PR DESCRIPTION
This adds the [tf2centerprojectiles plugin](https://github.com/rtldg/tf2centerprojectiles) and its dependency [tf2attributes](https://github.com/FlaminSarge/tf2attributes) (and tf2attributes.smx needs to be built too). DHooks is needed (dhooks.inc to compile) but I think I got red to mention something about that.

This adds the command `sm_centerprojectiles` which players can use to toggle centering projectiles from rocket launchers (making them all shoot like it's The Original), grenade launchers, sticky launchers, huntsman, crusader's crossbow, and a few more random primary-slot projectile-based weapons. `sm_centerprojectiles 1` and `sm_centerprojectiles 0` also work.

[example video](https://www.youtube.com/watch?v=ciCpVSi6AZk)