### PR TITLE
Restore configs overridden by SMod update

### DIFF
--- a/roles/tf2/files/tf/addons/sourcemod/configs/admin_overrides.cfg
+++ b/roles/tf2/files/tf/addons/sourcemod/configs/admin_overrides.cfg
@@ -17,5 +17,7 @@ Overrides
 	 *
 	 * You can make a command completely public by using an empty flag string.
 	 */
+
+	 "admin_allspec_flag"    "b"
 }
 

--- a/roles/tf2/files/tf/addons/sourcemod/translations/reservedslots.phrases.txt
+++ b/roles/tf2/files/tf/addons/sourcemod/translations/reservedslots.phrases.txt
@@ -2,6 +2,6 @@
 {
 	"Slot reserved"
 	{
-		"en"			"Dropped due to slot reservation"
+		"en"			"The server is full. Please try again later"
 	}
 }

--- a/roles/tf2/files/tf/cfg/sourcemod/sourcemod.cfg
+++ b/roles/tf2/files/tf/cfg/sourcemod/sourcemod.cfg
@@ -11,7 +11,7 @@
 // 16: Always show admin names to root users.
 // --
 // Default: 13 (1+4+8)
-sm_show_activity 13
+sm_show_activity 31
 
 // Specifies whether menu sounds are enabled for menus created by SourceMod.
 // Menu sounds can be further configured in addons/sourcemod/configs/core.cfg.
@@ -19,8 +19,8 @@ sm_show_activity 13
 // Default: 1
 sm_menu_sounds 1
 
-// Specifies how long of a delay, in seconds, should be used in between votes 
-// that are "public" or can be spammed.  Whether or not this delay is obeyed 
+// Specifies how long of a delay, in seconds, should be used in between votes
+// that are "public" or can be spammed.  Whether or not this delay is obeyed
 // is dependent on the menu/command.
 // --
 // Default: 30
@@ -33,7 +33,7 @@ sm_vote_delay 30
 // 12 hour format: %m/%d/%Y - %I:%M:%S %p
 sm_datetime_format "%m/%d/%Y - %H:%M:%S"
 
-// Sets how SourceMod should check immunity levels when administrators target 
+// Sets how SourceMod should check immunity levels when administrators target
 // each other.
 // 0: Ignore immunity levels (except for specific group immunities).
 // 1: Protect from admins of lower access only.
@@ -41,10 +41,10 @@ sm_datetime_format "%m/%d/%Y - %H:%M:%S"
 // 3: Same as 2, except admins with no immunity can affect each other.
 // --
 // Default: 1
-sm_immunity_mode 1
+sm_immunity_mode 0
 
-// Sets how many seconds SourceMod should adjust time values for incorrect 
-// server clocks.  This can be positive or negative and will affect every 
+// Sets how many seconds SourceMod should adjust time values for incorrect
+// server clocks.  This can be positive or negative and will affect every
 // system time in SourceMod, including logging stamps.
 // --
 // Default: 0
@@ -57,13 +57,13 @@ sm_time_adjustment 0
 // --
 // Requires: antiflood.smx
 // Default: 0.75
-sm_flood_time 0.75
+sm_flood_time 1.0
 
 // Specifies how the reserved slots plugin operates. Valid values are:
 // 0 : Public slots are used in preference to reserved slots. Reserved slots are freed before public slots.
-// 1 : If someone with reserve access joins into a reserved slot, the player with the highest latency and 
+// 1 : If someone with reserve access joins into a reserved slot, the player with the highest latency and
 // no reserved slot access (spectator players are selected first) is kicked to make room. Thus, the reserved
-// slots always remains free. The only situation where the reserved slot(s) can become properly occupied is 
+// slots always remains free. The only situation where the reserved slot(s) can become properly occupied is
 // if the server is full with reserve slot access clients.
 // 2 : The same as sm_reserve_type 1 except once a certain number of admins have been reached, the reserve slot
 // stops kicking people and anyone can join to fill the server. You can use this to simulate having a large
@@ -81,14 +81,14 @@ sm_reserve_type 0
 // --
 // Requires: reservedslots.smx
 // Default: 0
-sm_reserved_slots 0
+sm_reserved_slots 8
 
 // Specifies whether or not reserved slots will be hidden (subtracted from max
 // slot count). Valid values are 0 (Visible) or 1 (Hidden).
 // --
 // Requires: reservedslots.smx
 // Default: 0
-sm_hide_slots 0
+sm_hide_slots 1
 
 // Specifies whether or not non-admins can send messages to admins using
 // say_team @<message>. Valid values are 0 (Disabled) or 1 (Enabled)
@@ -117,7 +117,7 @@ sm_trigger_show 0
 // Valid values are 0 (Disabled) or 1 (Enabled).
 // --
 // Default: 0
-sm_vote_progress_hintbox 0
+sm_vote_progress_hintbox 1
 
 // Specifies whether or not to display vote progress to clients in the
 // chat area. Valid values are 0 (Disabled) or 1 (Enabled).


### PR DESCRIPTION
SourceMod update in 56c186e686ffd745ea52c7a1d1855a0ecf796c5a accidentally overwrote some of the configs, so this PR restores them to how they were in 0fd8d681ef23158fed4a3b0f5dd7c11a4f478419.

Resolves #109