### PR TITLE
Tweak kernel network settings for UDP performance

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -178,7 +178,7 @@
     value: 26214400
     sysctl_set: yes
     reload: yes
-    
+
 - name: Increase available memory for UDP send buffers
   become: yes
   ansible.posix.sysctl:
@@ -194,4 +194,4 @@
     value: 25000
     sysctl_set: yes
     reload: yes
-    
+

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -170,3 +170,28 @@
     src: 50unattended-upgrades
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     mode: '644'
+
+- name: Increase available memory for UDP receive buffers
+  become: yes
+  ansible.posix.sysctl:
+    name: net.core.rmem_max
+    value: 26214400
+    sysctl_set: yes
+    reload: yes
+    
+- name: Increase available memory for UDP send buffers
+  become: yes
+  ansible.posix.sysctl:
+    name: net.core.wmem_max
+    value: 26214400
+    sysctl_set: yes
+    reload: yes
+
+- name: Increase the maximum amount of packages in the kernel queue
+  become: yes
+  ansible.posix.sysctl:
+    name: net.core.netdev_max_backlog
+    value: 25000
+    sysctl_set: yes
+    reload: yes
+    


### PR DESCRIPTION
(These parameters are still a work in progress, don't merge yet!)

The servers are occasionally dropping packages, these changes will
hopefully alleviate that by significantly increasing the memory
available to the kernel for UDP packages, as well as the amount of
packages that will be allowed to wait in the backlog for the kernel to
process them.

Reference: https://www.kernel.org/doc/Documentation/sysctl/net.txt