### PR TITLE
Add a simple rcon client as an Ansible module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Install Ansible & Clone playbooks
 - `sudo apt-add-repository --yes --update ppa:ansible/ansible`
 - `apt install ansible make git git-lfs sshpass -y` [or for macOS](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-macos)
 - `git clone git@github.com:leighmacdonald/uncletopia`
+- `pip install rcon`
 
 ## Game Update Workflow
 

--- a/playbooks/library/rcon.py
+++ b/playbooks/library/rcon.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = r'''
+---
+module: rcon
+short_description: Remotely control game servers
+options:
+    address:
+        description: RCON-enabled game server remote address
+        required: true
+        type: str
+    port:
+        description: Game server port
+        required: true
+        type: int
+    password:
+        description: The rcon password
+        required: true
+        type: str
+    command:
+        description: What command to send
+        required: true
+        type: list
+author:
+    - viora (@crescentrose)
+'''
+
+EXAMPLES = r'''
+- name: Say "hello world" to a local TF2 server
+  rcon:
+    address: localhost
+    port: 27015
+    password: password
+    command: ['say', 'Hello, world!']
+'''
+
+RETURN = r'''
+response:
+    description: Response from the server, if any
+    type: str
+    returned: always
+    sample: "Console: hello, world!\nL 12/03/2022 - 16:37:03: \"Console<0><Console><Console>\" say \"hello, world!\"\n"
+'''
+
+from ansible.module_utils.basic import *
+from rcon.source import Client
+from rcon.exceptions import WrongPassword, EmptyResponse
+
+def rcon(addr: str, port: int, password: str, cmd: str):
+  with Client(addr, port, passwd=password) as client:
+    response = client.run(cmd)
+  return response
+
+def main():
+  fields = {
+    "address": {"required": True, "type": "str"},
+    "port": {"required": True, "type": "int"},
+    "password": {"required": True, "type": "str", "no_log": True},
+    "command": {"required": True, "type": "str"}
+  }
+
+  module = AnsibleModule(argument_spec=fields)
+
+  try:
+    response = rcon(
+      module.params['address'],
+      module.params['port'],
+      module.params['password'],
+      module.params['command']
+    )
+  except ConnectionError:
+    return module.fail_json("cannot connect to rcon host " + module.params['address'])
+  except WrongPassword:
+    return module.fail_json("wrong password provided for rcon host " + module.params['address'])
+  except EmptyResponse:
+    return module.fail_json("no response from rcon host " + module.params['address'])
+
+  module.exit_json(changed=True, meta={"response": response})
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This would enable a simple task to announce an upcoming server update before players are disconnected and flock to Discord to ask what's up.

Example usage:

```yaml
- name: announce update
  ignore_errors: true
  rcon: 
    address: "{{ inventory_hostname }}"
    port: "{{ srcds_base_port + (loop0 * 10) }}"
    password: "{{ rcon_password }}"
    command: 'sm_csay Server is about to restart for updates.;sm_say Server is about to restart for updates.'
  loop: "{{ services }}"
  loop_control:
    index_var: loop0
```

I am unsure as to whether adding a requirement for the `rcon` pip package to be installed on the system is alright. So, if we agree that it is OK, then this can probably be merged.