### PR TITLE
fix Stopwatch Beta

### DIFF
--- a/roles/sourcemod/files/addons/sourcemod/scripting/gbans/globals.sp
+++ b/roles/sourcemod/files/addons/sourcemod/scripting/gbans/globals.sp
@@ -50,6 +50,7 @@ ConVar gDemoPathComplete = null;
 ConVar gStopwatchEnabled = null;
 ConVar gStopwatchNameRed = null;
 ConVar gStopwatchNameBlu = null;
+ConVar gStopwatchChangelvlTime = null;
 
 // Game ruleset options
 ConVar gRulesRoundTime = null;


### PR DESCRIPTION
fixes the Stopwatch Beta gamemode. tested on pl_upward, pl_swiftwater_final, pl_summercoast_rc8e, cp_sunshine, and cp_process_final with results as expected in each.

there is probably a better fix that can replace gb_stopwatch_changelevel_time involving using sm_mapvote_voteduration from nativevotes_mapchooser.sp to ensure the mapvote finishes, 35 should work on Uncletopia config.