### PR TITLE
Add single-letter commands to speed up common votes

### DIFF
--- a/roles/sourcemod/files/addons/sourcemod/scripting/nativevotes_nominations.sp
+++ b/roles/sourcemod/files/addons/sourcemod/scripting/nativevotes_nominations.sp
@@ -242,7 +242,7 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
 		return;
 	}
 	
-	if (strcmp(sArgs, "nominate", false) == 0)
+	if (strcmp(sArgs, "nominate", false) == 0 || strcmp(sArgs, "n", false) == 0 )
 	{
 		ReplySource old = SetCmdReplySource(SM_REPLY_TO_CHAT);
 		

--- a/roles/sourcemod/files/addons/sourcemod/scripting/votescramble.sp
+++ b/roles/sourcemod/files/addons/sourcemod/scripting/votescramble.sp
@@ -143,7 +143,7 @@ public Action Cmd_VoteScramble(int client, int args)
 
 public void OnClientSayCommand_Post(int client, const char[] command, const char[] sArgs)
 {
-	if (strcmp(sArgs, "votescramble", false) == 0 || strcmp(sArgs, "vscramble", false) == 0 || strcmp(sArgs, "scramble", false) == 0 || strcmp(sArgs, "scrimblo", false) == 0 )
+	if (strcmp(sArgs, "votescramble", false) == 0 || strcmp(sArgs, "vscramble", false) == 0 || strcmp(sArgs, "scramble", false) == 0 || strcmp(sArgs, "scrimblo", false) == 0 || strcmp(sArgs, "s", false) == 0)
 	{
 		ReplySource old = SetCmdReplySource(SM_REPLY_TO_CHAT);
 


### PR DESCRIPTION
In a similar vein to how "rock the vote" is shortened to "rtv", it was suggested in the Discord by Psyche that scramble and nominate - being the two other most common votes to take place on the servers - should also have a shorthand to kick them off. There's not really any reason not to since it saves people's time, and has no practical negatives.

As such, this PR simply adds !s and !n as aliases for !scramble and !nominate respectively. 