### PR TITLE
Adjust idle kick timer on 1000 Uncles

### DIFF
--- a/roles/srcds/templates/autoexec.cfg.j2
+++ b/roles/srcds/templates/autoexec.cfg.j2
@@ -42,7 +42,7 @@ sv_voiceenable 1
 sv_voicecodec steam
 
 // AFK Kick after 3 mins
-mp_idlemaxtime 3
+mp_idlemaxtime {% if item.pve_mode|default(false) %}10{% else %}5{% endif %}
 
 sv_visiblemaxplayers {{ item.sv_visiblemaxplayers|default(24) }}
 

--- a/roles/srcds/templates/autoexec.cfg.j2
+++ b/roles/srcds/templates/autoexec.cfg.j2
@@ -42,7 +42,7 @@ sv_voiceenable 1
 sv_voicecodec steam
 
 // AFK Kick after 3 mins
-mp_idlemaxtime {% if item.pve_mode|default(false) %}10{% else %}5{% endif %}
+mp_idlemaxtime {% if item.pve_mode|default(false) %}10{% else %}3{% endif %}
 
 sv_visiblemaxplayers {{ item.sv_visiblemaxplayers|default(24) }}
 


### PR DESCRIPTION
Another suggestion from the Discord. Raises the idle kick on 1000 Uncles Mode to 10 minutes, to account for spectators as they apparently get auto-kicked at the moment. 